### PR TITLE
fix the overflow vulnerability

### DIFF
--- a/src/uct_upstream.c
+++ b/src/uct_upstream.c
@@ -134,7 +134,7 @@ power(uct_int_t x, uct_int_t n)
 {
     if (n == 0)
         return 1;
-    int res = power(x, n / 2);
+    uct_int_t res = power(x, n / 2);
     if (n % 2 != 0)
         return res * res * x;
     else


### PR DESCRIPTION
Multiplication result converted to larger type:  The code that converts the result of an integer multiplication to a larger type. Since the conversion applies after the multiplication, arithmetic overflow may still occur.

fix the vulnerability mentioned in https://github.com/SunBK201/umicat/issues/2